### PR TITLE
Build on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi
+          
+      - name: Install Pico SDK
+        run: |
+          git clone https://github.com/raspberrypi/pico-sdk.git
+          cd pico-sdk
+          git submodule update --init --recursive
+          cd ..
+
+      - name: Build
+        run: |
+          export PICO_SDK_PATH=../../pico-sdk
+          export PATH=$PICO_SDK_PATH/tools:$PATH
+          cd C-Code
+          mkdir build
+          cd build
+          cmake -DPICO_BOARD=pico ..
+          make
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          path: C-Code/build/*.uf2


### PR DESCRIPTION
This automatically builds the `.uf2` using GitHub Actions.

This is useful to provide binaries to users who don't want to set up a local build system, and allows to check every pull request for buildability.